### PR TITLE
891533: Infinite loop occurs in Recurrence Helper

### DIFF
--- a/RecurrenceHelper.cs
+++ b/RecurrenceHelper.cs
@@ -726,24 +726,24 @@ namespace ScheduleSample
                                     var lastDate = ScheduleUtils.LastDateOfMonth(monthStart);
                                     addDate = ScheduleUtils.GetWeekFirstDate(lastDate, nthweekDay);
                                 }
-                                if(setPosCount == 0)
+                                else if (setPosCount == 0)
                                 {
-                                    while(!IsUntilDateReached)
+                                    while (!IsUntilDateReached)
                                     {
-                                        if(int.Parse(BYMONTHCOUNT) == addDate.Month)
+                                        if (int.Parse(BYMONTHCOUNT) == addDate.Month)
                                         {
-                                            GetWeeklyDateCollection(addDate,weeklyRule,RecDateCollection);
+                                            GetWeeklyDateCollection(addDate, weeklyRule, RecDateCollection);
                                             addDate = addDate.AddDays(1);
                                         }
                                         else
                                         {
                                             addDate = addDate.AddMonths(1);
                                         }
-                                        if(addDate.CompareTo(endDate) > 0)
+                                        if (addDate.CompareTo(endDate) > 0)
                                         {
                                             IsUntilDateReached = true;
                                         }
-                                    }   
+                                    }
                                 }
                                 else
                                 {

--- a/RecurrenceHelper.cs
+++ b/RecurrenceHelper.cs
@@ -119,7 +119,7 @@ namespace ScheduleSample
                     summary += (space + "day(s)");
                     break;
                 case "WEEKLY":
-                    summary += space + ( "week(s)") + space + ( "on") + space;
+                    summary += space + ("week(s)") + space + ("on") + space;
                     string[] days = weeklyByDay.Split('=')[1].Split(',');
                     int index = 0;
                     foreach (string day in days)
@@ -132,11 +132,11 @@ namespace ScheduleSample
 
                     break;
                 case "MONTHLY":
-                    summary += space + ( "months(s)") + space + ( "on");
+                    summary += space + ("months(s)") + space + ("on");
                     summary += GetMonthSummary(totalDays, byMonthDayCount, byDayValue, bySetPosCount);
                     break;
                 case "YEARLY":
-                    summary += space + ( "year(s)") + space + ("on") + space;
+                    summary += space + ("year(s)") + space + ("on") + space;
                     summary += totalMonths[int.Parse(byMonthCount, CultureInfo.InvariantCulture) - 1];
                     summary += GetMonthSummary(totalDays, byMonthDayCount, byDayValue, bySetPosCount);
                     break;
@@ -149,7 +149,7 @@ namespace ScheduleSample
             else if (!string.IsNullOrEmpty(untilValue))
             {
                 var tempDate = DateTime.ParseExact(untilValue, "yyyyMMddTHHmmssZ", CultureInfo.CurrentCulture);
-                summary += comma + space + ( "until") + space + tempDate.Day + space + totalMonths[tempDate.Month - 1] + space + tempDate.Year;
+                summary += comma + space + ("until") + space + tempDate.Day + space + totalMonths[tempDate.Month - 1] + space + tempDate.Year;
             }
 
             return summary;
@@ -165,9 +165,9 @@ namespace ScheduleSample
             }
             else if (!string.IsNullOrEmpty(byDayValue))
             {
-                int nthweekDay = GetWeekDay(byDayValue) -1;
+                int nthweekDay = GetWeekDay(byDayValue) - 1;
                 var pos = int.Parse(bySetPosCount, CultureInfo.InvariantCulture) - 1;
-                var weekPos = pos > -1 ?  weekPositions[pos] : weekPositions[weekPositions.Length -1];
+                var weekPos = pos > -1 ? weekPositions[pos] : weekPositions[weekPositions.Length - 1];
                 summary += weekPos + " " + days[nthweekDay];
             }
 
@@ -679,6 +679,8 @@ namespace ScheduleSample
                         else if (UNTIL != null)
                         {
                             bool IsUntilDateReached = false;
+                            DateTime prevDate = new DateTime();
+
                             while (!IsUntilDateReached)
                             {
                                 var weekCount = MondaysInMonth(addDate);
@@ -730,10 +732,15 @@ namespace ScheduleSample
                                 {
                                     addDate = weekStartDate.AddDays((nthWeek) * 7);
                                     addDate = addDate.AddDays(nthweekDay);
+                                    if (addDate.CompareTo(prevDate) < 0)
+                                    {
+                                        addDate = prevDate;
+                                    }
                                 }
                                 if (addDate.CompareTo(startDate.Date) < 0)
                                 {
                                     addDate = addDate.AddYears(1);
+                                    prevDate = addDate;
                                     continue;
                                 }
                                 if (DateTime.Compare(addDate.Date, Convert.ToDateTime(UNTIL)) <= 0)

--- a/RecurrenceHelper.cs
+++ b/RecurrenceHelper.cs
@@ -679,8 +679,6 @@ namespace ScheduleSample
                         else if (UNTIL != null)
                         {
                             bool IsUntilDateReached = false;
-                            DateTime prevDate = new DateTime();
-
                             while (!IsUntilDateReached)
                             {
                                 var weekCount = MondaysInMonth(addDate);
@@ -728,19 +726,33 @@ namespace ScheduleSample
                                     var lastDate = ScheduleUtils.LastDateOfMonth(monthStart);
                                     addDate = ScheduleUtils.GetWeekFirstDate(lastDate, nthweekDay);
                                 }
+                                if(setPosCount == 0)
+                                {
+                                    while(!IsUntilDateReached)
+                                    {
+                                        if(int.Parse(BYMONTHCOUNT) == addDate.Month)
+                                        {
+                                            GetWeeklyDateCollection(addDate,weeklyRule,RecDateCollection);
+                                            addDate = addDate.AddDays(1);
+                                        }
+                                        else
+                                        {
+                                            addDate = addDate.AddMonths(1);
+                                        }
+                                        if(addDate.CompareTo(endDate) > 0)
+                                        {
+                                            IsUntilDateReached = true;
+                                        }
+                                    }   
+                                }
                                 else
                                 {
                                     addDate = weekStartDate.AddDays((nthWeek) * 7);
                                     addDate = addDate.AddDays(nthweekDay);
-                                    if (addDate.CompareTo(prevDate) < 0)
-                                    {
-                                        addDate = prevDate;
-                                    }
                                 }
                                 if (addDate.CompareTo(startDate.Date) < 0)
                                 {
                                     addDate = addDate.AddYears(1);
-                                    prevDate = addDate;
                                     continue;
                                 }
                                 if (DateTime.Compare(addDate.Date, Convert.ToDateTime(UNTIL)) <= 0)


### PR DESCRIPTION
### Bug description
Infinite loop occurs in Recurrence Helper for the given recurrence rule. "FREQ=YEARLY;BYMONTH=1;BYDAY=SU,MO,TU,WE,TH,FR,SA;UNTIL=20250131T235959Z"

### Root cause
The recurrence rule provided by the customer contains multiple BYDAY values and does not include a BYSETPOS value. The existing code, which is designed to handle only one BYDAY value and BYSETPOS when it’s “-1” or less than 0 for that specific rule provided by customer, results in an infinite loop due to the missing BYSETPOS value.

### Solution description
I resolved this issue by incorporating the BYSETPOS value when it is 0 or missing. I also managed the multiple BYDAY values in accordance with the given recurrence rule. This will generate the correct dates, regardless of whether the BYSETPOS value is present or not.